### PR TITLE
Change web component selector prefixes

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -17,7 +17,7 @@
       "test": "test.ts",
       "tsconfig": "tsconfig.app.json",
       "testTsconfig": "tsconfig.spec.json",
-      "prefix": "app",
+      "prefix": "frees",
       "styles": [
         "styles.scss"
       ],

--- a/e2e/app.po.ts
+++ b/e2e/app.po.ts
@@ -6,6 +6,6 @@ export class AppPage {
   }
 
   getParagraphText() {
-    return element(by.css('app-root h1')).getText();
+    return element(by.css('frees-root h1')).getText();
   }
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -36,7 +36,7 @@
       </md-sidenav>
 
       <section class="sidenav-content">
-        <app-breadcrumb></app-breadcrumb>
+        <frees-breadcrumb></frees-breadcrumb>
         <router-outlet></router-outlet>
       </section>
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-  selector: 'app-root',
+  selector: 'frees-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
 })

--- a/src/app/breadcrumb/breadcrumb.component.ts
+++ b/src/app/breadcrumb/breadcrumb.component.ts
@@ -3,7 +3,7 @@ import { Router, Event, ActivatedRoute, ActivatedRouteSnapshot, NavigationEnd } 
 
 
 @Component({
-  selector: 'app-breadcrumb',
+  selector: 'frees-breadcrumb',
   templateUrl: './breadcrumb.component.html',
   styleUrls: ['./breadcrumb.component.scss']
 })

--- a/src/app/ms-viewer/ms-viewer.component.ts
+++ b/src/app/ms-viewer/ms-viewer.component.ts
@@ -8,7 +8,7 @@ import { Metric } from 'app/shared/metric.model';
 import { MetricService } from 'app/services/metric.service';
 
 @Component({
-  selector: 'app-ms-viewer',
+  selector: 'frees-ms-viewer',
   templateUrl: './ms-viewer.component.html',
   styleUrls: ['./ms-viewer.component.scss']
 })

--- a/src/app/nav-grid/nav-grid.component.ts
+++ b/src/app/nav-grid/nav-grid.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 
 @Component({
-  selector: 'app-nav-grid',
+  selector: 'frees-nav-grid',
   templateUrl: './nav-grid.component.html',
   styleUrls: ['./nav-grid.component.scss']
 })

--- a/src/app/page-not-found/page-not-found.component.ts
+++ b/src/app/page-not-found/page-not-found.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 
 @Component({
-  selector: 'app-page-not-found',
+  selector: 'frees-page-not-found',
   templateUrl: './page-not-found.component.html',
   styleUrls: ['./page-not-found.component.scss']
 })

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 
 @Component({
-  selector: 'app-settings',
+  selector: 'frees-settings',
   templateUrl: './settings.component.html',
   styleUrls: ['./settings.component.scss']
 })

--- a/src/index.html
+++ b/src/index.html
@@ -9,6 +9,6 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>
 <body>
-  <app-root></app-root>
+  <frees-root></frees-root>
 </body>
 </html>

--- a/tslint.json
+++ b/tslint.json
@@ -117,13 +117,21 @@
     "directive-selector": [
       true,
       "attribute",
-      "app",
+      [
+        "app",
+        "foca",
+        "frees"
+      ],
       "camelCase"
     ],
     "component-selector": [
       true,
       "element",
-      "app",
+      [
+        "app",
+        "foca",
+        "frees"
+      ],
       "kebab-case"
     ],
     "use-input-property-decorator": true,


### PR DESCRIPTION
* This is done to prevent name collisions and to reflect Freestyle Opscenter web components instead of the generic `app`

This fixes #19.