### PR TITLE
Update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2408,7 +2408,7 @@
       "dev": true,
       "requires": {
         "fs-extra": "0.23.1",
-        "handlebars": "1.3.0",
+        "handlebars": "4.0.11",
         "img-stats": "0.5.2"
       },
       "dependencies": {
@@ -3486,8 +3486,8 @@
       "dev": true
     },
     "handlebars": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
       "integrity": "sha1-npsTCpPjiUkTItl1zz7BgYw3zjQ=",
       "dev": true,
       "requires": {


### PR DESCRIPTION
Update handlebars peer-dependency as a temporary workaround for a security vulnerability.

* This dependency was updated 3 days ago on the project that really depends on this affected library, but until we update our dependencies this is a workaround to fix it already.
* For more info see https://github.com/angular/angular-cli/pull/8535