### PR TITLE
Refactor main navigation grid

### DIFF
--- a/mock-server/index.js
+++ b/mock-server/index.js
@@ -25,8 +25,14 @@ app.ws('/metrics', function (ws, req) {
 
 setInterval(function () {
   expressWs.getWss('/metrics').clients.forEach(function (client) {
-    var blob = new Buffer('microservice1 ' + Date.now() + ' cassandra.topics ' + (Math.random() * 100));
-    client.send(blob);
+    var blob1 = new Buffer('microservice1 ' + Date.now() + ' cassandra.topics ' + (Math.random() * 100));
+    var blob2 = new Buffer('microservice2 ' + Date.now() + ' cassandra.topics ' + (Math.random() * 100));
+    var blob3 = new Buffer('microservice3 ' + Date.now() + ' cassandra.topics ' + (Math.random() * 100));
+    var blob4 = new Buffer('microservice4 ' + Date.now() + ' cassandra.topics ' + (Math.random() * 100));
+    client.send(blob1);
+    client.send(blob2);
+    client.send(blob3);
+    client.send(blob4);
   });
 }, 2000);
 

--- a/src/app/ms-viewer/ms-viewer.component.html
+++ b/src/app/ms-viewer/ms-viewer.component.html
@@ -19,37 +19,21 @@
     </button>
 
     <div *ngIf="isCurrentlyListening()">
-      <mat-grid-list cols="2" rowHeight="fit">
-        <mat-grid-tile>
-          <div>{{ metric?.microservice }}</div>
-        </mat-grid-tile>
-        <mat-grid-tile>
-          <div>{{ metric?.date | date:'y/MM/dd HH:mm:ss (Z)' }}</div>
-        </mat-grid-tile>
-        <mat-grid-tile>
-          <h2>{{ metric?.metric }}</h2>
-        </mat-grid-tile>
-        <mat-grid-tile>
-          <h2>{{ metric?.value | number:'1.7-7' }}</h2>
-        </mat-grid-tile>
-        <mat-grid-tile colspan="2">
-          <ngx-charts-line-chart 
-            [scheme]="colorScheme"
-            [results]="chartData"
-            [gradient]="gradient"
-            [xAxis]="showXAxis"
-            [yAxis]="showYAxis"
-            [legend]="showLegend"
-            [showXAxisLabel]="showXAxisLabel"
-            [showYAxisLabel]="showYAxisLabel"
-            [xAxisLabel]="xAxisLabel"
-            [yAxisLabel]="yAxisLabel"
-            [autoScale]="autoScale"
-            [animations]="animations"
-            (select)="onSelect($event)">
-          </ngx-charts-line-chart>
-        </mat-grid-tile>
-      </mat-grid-list>
+        <ngx-charts-line-chart 
+          [scheme]="colorScheme"
+          [results]="chartData"
+          [gradient]="gradient"
+          [xAxis]="showXAxis"
+          [yAxis]="showYAxis"
+          [legend]="showLegend"
+          [showXAxisLabel]="showXAxisLabel"
+          [showYAxisLabel]="showYAxisLabel"
+          [xAxisLabel]="xAxisLabel"
+          [yAxisLabel]="yAxisLabel"
+          [autoScale]="autoScale"
+          [animations]="animations"
+          (select)="onSelect($event)">
+        </ngx-charts-line-chart>
       <mat-progress-bar mode="query"></mat-progress-bar>
     </div>
 

--- a/src/app/ms-viewer/ms-viewer.component.ts
+++ b/src/app/ms-viewer/ms-viewer.component.ts
@@ -97,7 +97,6 @@ export class MsViewerComponent implements OnInit {
      * string type parameter to be able to acces the split property, because
      * after the mergeAll we are getting a string and not a Promise<string>.
      */
-    // this.subscription = this.metricService.getSubject('handshake')
     this.subscription = this.metricService.getSubject().pipe(
       mergeAll(1),
       map(_ => new Metric(..._.split(' '))),

--- a/src/app/nav-grid/nav-grid.component.html
+++ b/src/app/nav-grid/nav-grid.component.html
@@ -1,5 +1,8 @@
 <mat-grid-list class="tile-list" cols="2" rowHeight="fit">
-  <mat-grid-tile class="tile" *ngFor="let link of links" routerLink="/ms/{{ link | number:'2.0-0'}}">
-    <h2>Microservice MS{{ link | number:'2.0-0'}}</h2>
+  <mat-grid-tile class="tile" *ngFor="let link of links">
+    <h2 class="tile-link" routerLink="/ms/{{ link | number:'2.0-0'}}">
+      Microservice MS{{ link | number:'2.0-0'}}
+    </h2>
+    <frees-ms-viewer></frees-ms-viewer>
   </mat-grid-tile>
 </mat-grid-list>

--- a/src/app/nav-grid/nav-grid.component.scss
+++ b/src/app/nav-grid/nav-grid.component.scss
@@ -8,11 +8,20 @@
   flex: 1 1 auto;
 
   .tile {
-    transition: background-color .3s ease;
 
-    &:hover {
-      background-color: rgba(0,0,0,.05);
-      cursor: pointer;
+    // We need this ng-deep to be able to change the flex-direction
+    // property of the tiles inner content, as it's not configurable
+    ::ng-deep .mat-figure {
+      flex-direction: column;
+    }
+
+    .tile-link {
+      transition: color .3s ease;
+    
+      &:hover {
+        color: rgba(0,0,0,.75);
+        cursor: pointer;
+      }
     }
   }
 }

--- a/src/app/nav-grid/nav-grid.component.ts
+++ b/src/app/nav-grid/nav-grid.component.ts
@@ -7,7 +7,8 @@ import { Component, OnInit } from '@angular/core';
 })
 export class NavGridComponent implements OnInit {
 
-  links = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+  // TODO: Get this data from the server
+  links = [1, 2, 3, 4];
 
   constructor() { }
 

--- a/src/app/services/metric.service.ts
+++ b/src/app/services/metric.service.ts
@@ -33,6 +33,8 @@ export class MetricService {
   private wscResultSelector(e: MessageEvent): any {
     const reader = new FileReader();
 
+    // TODO: Wrap this FileReader into an Observable instead
+    // of a Promise to a more suited chaining later on
     const promise = new Promise<string>((resolve, reject) => {
       reader.onloadend = (event) => {
         // const dataResult = event.target.result;
@@ -64,7 +66,7 @@ export class MetricService {
   getSubject<T = string>(handshake?: T): WebSocketSubject<T> {
     const subject: WebSocketSubject<T> = webSocket(this.wsc);
     if (handshake) {
-      // If the websocket is “cold” we need to send a first message to get it started
+      // If the websocket is “cold” we need to send an initial message to get it started
       // const handshake = new Blob(['handshake'], {
       //   type: 'text/plain'
       // });


### PR DESCRIPTION
* Add differentiated microservices metrics

   * Set the mock-server to send different microservices metrics on a same websocket.
   * Make needed on changes on ms-viewer component to be able to discriminate between this different content on a same websocket.
   * The asynchrony is now controlled by flattening a higher-order Observable through the mergeAll operator.


* Inject ms-viewer into nav-grid component

  * Reorganize the nav-grid content by injecting a ms-viewer component onto each tile.
  * Simplify the ms-viwer content to get nearer to the final proposed design.
  * Styling changes to adapt the new component.

This closes #36 
